### PR TITLE
Fix redis TTL param handling

### DIFF
--- a/my-app/src/lib/types/redis.d.ts
+++ b/my-app/src/lib/types/redis.d.ts
@@ -20,7 +20,11 @@ export interface RedisOptions {
 export interface RedisClient {
   // String operations with generic type support
   get<T = string>(key: string): Promise<T | null>;
-  set<T = string>(key: string, value: T, ttl?: number): Promise<'OK'>;
+  set<T = string>(
+    key: string,
+    value: T,
+    ttl?: number | { ex?: number; nx?: boolean; xx?: boolean }
+  ): Promise<'OK'>;
   del(keys: string | string[]): Promise<number>;
   exists(keys: string | string[]): Promise<number>;
   expire(key: string, seconds: number): Promise<number>;
@@ -51,7 +55,11 @@ export interface RedisClient {
   
   // JSON operations
   jsonGet<T = any>(key: string): Promise<T | null>;
-  jsonSet<T = any>(key: string, value: T, ttl?: number): Promise<'OK'>;
+  jsonSet<T = any>(
+    key: string,
+    value: T,
+    ttl?: number | { ex?: number; nx?: boolean; xx?: boolean }
+  ): Promise<'OK'>;
 }
 
 // Upstash Redis module augmentation
@@ -96,7 +104,11 @@ declare module '@upstash/redis' {
 export interface RedisClient {
   // String operations
   get(key: string): Promise<string | null>;
-  set(key: string, value: string, ttl?: number): Promise<'OK'>;
+  set(
+    key: string,
+    value: string,
+    ttl?: number | { ex?: number; nx?: boolean; xx?: boolean }
+  ): Promise<'OK'>;
   del(keys: string | string[]): Promise<number>;
   exists(keys: string | string[]): Promise<number>;
   expire(key: string, seconds: number): Promise<number>;


### PR DESCRIPTION
## Summary
- allow TTL to be passed as a number to the redis wrapper
- update redis types to reflect TTL options

## Testing
- `npx jest` *(fails: Need to install jest)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc42b1a788330a4f94d26e21c2979