### PR TITLE
Add redis inventory fetch service and API

### DIFF
--- a/my-app/src/app/api/inventory/route.test.ts
+++ b/my-app/src/app/api/inventory/route.test.ts
@@ -1,0 +1,34 @@
+jest.mock('@/lib/services/redisService');
+
+describe('/api/inventory', () => {
+  let GET: typeof import('./route').GET;
+  let mockedService: jest.Mocked<typeof import('@/lib/services/redisService')>;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const routeModule = await import('./route');
+    const serviceModule = await import('@/lib/services/redisService');
+    GET = (routeModule as { GET: typeof GET }).GET;
+    mockedService = serviceModule as jest.Mocked<typeof serviceModule>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns inventory data from redis', async () => {
+    const mockData = { vehicles: [{ id: '1' }], lastUpdated: 'now' };
+    mockedService.redisService.getInventoryData.mockResolvedValue(mockData as any);
+    const response = await GET();
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data).toEqual(mockData);
+    expect(mockedService.redisService.getInventoryData).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 500 on error', async () => {
+    mockedService.redisService.getInventoryData.mockRejectedValue(new Error('fail'));
+    const response = await GET();
+    expect(response.status).toBe(500);
+  });
+});

--- a/my-app/src/app/api/inventory/route.ts
+++ b/my-app/src/app/api/inventory/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { redisService } from '@/lib/services/redisService';
+
+export async function GET() {
+  try {
+    const data = await redisService.getInventoryData();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[API] inventory GET error', error);
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/my-app/src/lib/services/redisService.ts
+++ b/my-app/src/lib/services/redisService.ts
@@ -22,6 +22,7 @@ const MEDIA_KEY = (id: string) => `media:${id}`;
 const VEHICLE_MEDIA_KEY = (vehicleId: string) => `vehicle:${vehicleId}:media`;
 const UNATTACHED_MEDIA_KEY = 'media:unattached';
 const SHOWROOM_CACHE_KEY = 'showroom:data';
+const INVENTORY_CACHE_KEY = 'dealership:inventory';
 
 // TTL in seconds (1 hour)
 const DEFAULT_TTL = 60 * 60;
@@ -182,12 +183,12 @@ export const redisService = {
   },
 
   // Get showroom data with Redis caching
-  async getShowroomData(useCache = true): Promise<{ 
-    vehicles: Vehicle[]; 
-    customMedia: Media[]; 
-    cachedAt: number; 
-    fromCache: boolean; 
-    error?: string 
+  async getShowroomData(useCache = true): Promise<{
+    vehicles: Vehicle[];
+    customMedia: Media[];
+    cachedAt: number;
+    fromCache: boolean;
+    error?: string
   }> {
     const cacheKey = SHOWROOM_CACHE_KEY;
     
@@ -257,6 +258,21 @@ export const redisService = {
         error: error instanceof Error ? error.message : 'Failed to load showroom data',
       };
     }
+  },
+
+  /**
+   * Retrieve the raw inventory data scraped from the dealership website.
+   */
+  async getInventoryData(): Promise<{ vehicles: any[]; lastUpdated?: string }> {
+    const data = await redisClient.jsonGet<{ vehicles?: any[]; lastUpdated?: string }>(INVENTORY_CACHE_KEY);
+    if (!data) {
+      return { vehicles: [] };
+    }
+
+    return {
+      vehicles: Array.isArray(data.vehicles) ? data.vehicles : [],
+      lastUpdated: data.lastUpdated,
+    };
   },
 };
 


### PR DESCRIPTION
## Summary
- add `INVENTORY_CACHE_KEY` constant and implement `getInventoryData` in `redisService`
- expose new `/api/inventory` endpoint
- add tests for the new endpoint

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/react', missing env vars, etc.)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e97fda7308330a26fdd44d3549155